### PR TITLE
Mandatory fields missing creating the Machine

### DIFF
--- a/src/compute.py
+++ b/src/compute.py
@@ -41,7 +41,8 @@ def create_machine(rack):
     datastore.setEnabled(True)
     machine.setVirtualSwitch(vswitch)
     machine.setRack(rack)
-
+    machine.setPassword(PM_PASSWORD)
+    machine.setUser(PM_USER)
     machine.save()
 
     return machine


### PR DESCRIPTION
The fields User and Password are mandatory in the Machine.

I did not add the test as I assume that there is already a failing test that creates a Machine in a rack.
