### PR TITLE
Added a function specific for bpm-async and a generalization to deploy rs

### DIFF
--- a/kahuna/plugins/scalability.py
+++ b/kahuna/plugins/scalability.py
@@ -185,7 +185,7 @@ class ScalabilityPlugin(AbsPlugin):
                 bootstrap.extend(hostname.configure(node))
                 bootstrap.append(ntp.install())
                 if options.jenkins:
-                    bootstrap.append(jenkins._download_war(
+                    bootstrap.extend(jenkins._download_war(
                         options.jenkins, "api"))
                 bootstrap.extend(tomcat.install_and_configure(node,
                     tomcat_config, self._install_local_wars))
@@ -221,6 +221,8 @@ class ScalabilityPlugin(AbsPlugin):
         parser.add_option('-s', '--hypervisor-sessions', type="int", default=2,
                 help='Number of concurrent hypervisor sessions (default 2)',
                 action='store', dest='hypervisorsessions')
+        parser.add_option('-l', '--list', help='Upload only those wars (default all rs)',
+                default='rs', action='store', dest='wars')
         (options, args) = parser.parse_args(args)
 
         if not options.jenkins or not options.nfs or not options.rabbit:
@@ -275,7 +277,7 @@ class ScalabilityPlugin(AbsPlugin):
                     "hypervisor-sessions": options.hypervisorsessions
                 }
                 install_tomcat = tomcat.install_and_configure(node,
-                    tomcat_config, self._install_jenkins_rs(options.jenkins))
+                    tomcat_config, self._install_jenkins_wars(options.jenkins, options.wars))
                 bootstrap = hostname.configure(node) + \
                     [ntp.install()] + redis.install("2.6.4") + install_tomcat
                 responses.append(compute.submitScriptOnNode(node.getId(),
@@ -321,11 +323,12 @@ class ScalabilityPlugin(AbsPlugin):
             "do unzip -d ${f%.war} $f; done"))
         return script
 
-    def _install_jenkins_rs(self, version):
-        """ Downloads teh Remote Services wars from Jenkins """
+    def _install_jenkins_wars(self, version, wars = "rs"):
+        """ Downloads the Remote Services wars from Jenkins """
         def jenkins_download():
             script = []
-            script.extend(jenkins.download_rs(version))
+            for war in wars.split(","):
+                script.extend(jenkins._download_war(version, war))
             script.extend(self._install_local_wars())
             return script
         return jenkins_download
@@ -335,7 +338,6 @@ class ScalabilityPlugin(AbsPlugin):
             print "Error %s" % error.getMessage()
         for error in ex.getNodeErrors().values():
             print "Error %s" % error.getMessage()
-
 
 class NodeHasIp(Predicate):
     """ Implements a NodeMetadata predicate to find nodes by Ip """

--- a/kahuna/utils/jenkins.py
+++ b/kahuna/utils/jenkins.py
@@ -13,22 +13,21 @@ def download_rs(version):
     script.append(Statements.exec(
         "ensure_cmd_or_install_package_apt wget wget"))
     script.append(_download_war(version, "am"))
-    script.append(_download_war(version, "bpm-async"))
     script.append(_download_war(version, "nodecollector"))
     script.append(_download_war(version, "ssm"))
     script.append(_download_war(version, "virtualfactory"))
     script.append(_download_war(version, "vsm"))
-    script.append(_download_script(version, "v2v-diskmanager",
-        "/usr/local/bin"))
-    script.append(_download_script(version, "mechadora", "/usr/local/bin"))
-    script.append(Statements.exec("chmod a+x /usr/local/bin/*"))
+    script.extend(_download_bpm(version))
     return script
 
 
 def _download_war(version, file_name, destination="/tmp"):
     """ Downloads a given war from Jenkins """
-    return Statements.exec("wget -O %s/%s.war %s/%s/%s.war" %
-        (destination, file_name, JENKINS, version, file_name))
+    if file_name == "rs":
+        return _download_rs(version)
+    else:
+        return [Statements.exec("wget -O %s/%s.war %s/%s/%s.war" %
+            (destination, file_name, JENKINS, version, file_name))]
 
 
 def _download_script(version, file_name, destination="/tmp"):
@@ -42,3 +41,14 @@ def _download_database(version, destination="/tmp"):
     return Statements.exec("wget -O %s/kinton-schema-%s.sql "
         "%s/%s/database/kinton-schema.sql" %
         (destination, version, JENKINS, version))
+
+def _download_bpm(version, destination="/tmp"):
+    """ Downloads a given war from Jenkins """
+    script = []
+    script.append(_download_war(version, "bpm-async", destination))
+    script.append(_download_script(version, "v2v-diskmanager",
+        "/usr/local/bin"))
+    script.append(_download_script(version, "mechadora", "/usr/local/bin"))
+    script.append(Statements.exec("chmod a+x /usr/local/bin/*"))
+    return script
+


### PR DESCRIPTION
With the -l or --list in the deploy-rs goal now we can deploy some of the rs to different virtual machines.
